### PR TITLE
[fix] fix missing tab completion

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Interface(options) {
   ReadlineInterface.call(this, options);
 }
 
+Interface.prototype._originalWriteToOutput = ReadlineInterface.prototype._writeToOutput;
 Interface.prototype._writeToOutput = function (stringToWrite) {
   if (stringToWrite === '\r\n' || stringToWrite === ' ') {
     this.output.write(stringToWrite);
@@ -39,6 +40,8 @@ Interface.prototype._writeToOutput = function (stringToWrite) {
     this.output.write(this._prompt);
     stringToWrite = stringToWrite.substring(this._prompt.length);
     renderCurrentLine(this, stringToWrite, true);
+  } else {
+    this._originalWriteToOutput(stringToWrite);
   }
 };
 


### PR DESCRIPTION
Tab completion is not working now. Because the `_writeToOutput` ignores completion which does not `startWithPrompt` 

Minimal reproduction:

``` javascript
var colorReadline = require('node-color-readline');
var chalk = require('colors');

var repl = colorReadline.createInterface({
  input: process.stdin,
  output: process.stdout,
  colorize: function (str) {
    // Make all occurences of 'e' red.
    return str.replace(/e/g, function (match) {
      return match.red;
    });
  },
  completer: completer
});

repl.on('line', function (cmd) {
  console.log('LINE:', cmd);
});

function completer(line) {
  var completions = '.help .error .exit .quit .q'.split(' ');
  var hits = completions.filter(function (c) { return c.indexOf(line) === 0;});
  // show all completions if none found
  return [hits.length ? hits : completions, line];
}

```
